### PR TITLE
Updates to newer JSON and Regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ Naive Bayes classifier
 keywords = ["naive-bayes", "bayesian", "classifier", "machine-learning"]
 
 [dependencies]
-rustc-serialize = "0.3.12"
-regex = "0.1.27"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+regex = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! ```
 //! meat examples from [baconipsum](http://baconipsum.com/), veggie examples from: [veggieipsum](http://veggieipsum.com/)
 
-extern crate rustc_serialize;
+extern crate serde;
 extern crate regex;
 
 mod naive_bayes;

--- a/src/naive_bayes.rs
+++ b/src/naive_bayes.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::f64;
 use regex::Regex;
-use rustc_serialize::json;
+use serde::{Serialize, Deserialize};
 
 static DEFAULT_SMOOTHING: f64 = 1.0f64;
 
 /// Naive Bayes classifier
-#[derive(Debug, Clone, RustcDecodable, RustcEncodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Classifier {
     vocab: HashSet<String>,
     num_examples: u32,
@@ -14,7 +14,7 @@ pub struct Classifier {
     classifications: HashMap<String, Classification>
 }
 
-#[derive(Debug, Clone, RustcDecodable, RustcEncodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Classification {
     label: String,
     num_examples: u32,
@@ -151,12 +151,12 @@ impl Classifier {
 
     /// Encodes the classifier as a JSON string.
     pub fn to_json(&self) -> String {
-        json::encode(self).ok().expect("encoding JSON failed")
+        serde_json::to_string(self).expect("encoding JSON failed")
     }
 
     /// Builds a new classifier from a JSON string
     pub fn from_json(encoded: &str) -> Classifier {
-        let classifier: Classifier = json::decode(encoded).ok().expect("decoding JSON failed");
+        let classifier: Classifier = serde_json::from_str(encoded).expect("decoding JSON failed");
         classifier
     }
 


### PR DESCRIPTION
Move to serde_json from the now deprecated rustc_serialize crate.
And bump regex to use 1.x. All tests pass, and food_document_test
does a serialize-deserialize loop back that covers this change.